### PR TITLE
Add getter to access locks status

### DIFF
--- a/src/AwaitLock.ts
+++ b/src/AwaitLock.ts
@@ -6,6 +6,14 @@ export default class AwaitLock {
   private _waitingResolvers: (() => void)[] = [];
 
   /**
+   * Whether the lock is currently acquired or not. Accessing this property does not affect the
+   * status of the lock.
+   */
+  get acquired(): boolean {
+    return this._acquired;
+  }
+  
+  /**
    * Acquires the lock, waiting if necessary for it to become free if it is already locked. The
    * returned promise is fulfilled once the lock is acquired.
    *
@@ -50,13 +58,5 @@ export default class AwaitLock {
     } else {
       this._acquired = false;
     }
-  }
-
-  /**
-   * Returns the current status of the lock
-   * without affecting its status
-   */
-  get acquired(): boolean {
-    return this._acquired;
   }
 }

--- a/src/AwaitLock.ts
+++ b/src/AwaitLock.ts
@@ -51,4 +51,12 @@ export default class AwaitLock {
       this._acquired = false;
     }
   }
+
+  /**
+   * Returns the current status of the lock
+   * without affecting its status
+   */
+  get acquired(): boolean {
+    return this._acquired;
+  }
 }


### PR DESCRIPTION
Hi, 
I added a getter to access the current status of the lock because I needed that in one of my projects.
I'm making this PR because I thought you might want to add that to the original package, if not, just reject this PR.


Thank you for the package!