### PR TITLE
Include src (sans tests) in published npm package for source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "types": "build/AwaitLock.d.ts",
   "files": [
     "build",
-    "!build/**/__tests__"
+    "src",
+    "!build/**/__tests__",
+    "!src/**/__tests__"
   ],
   "scripts": {
     "clean": "rm -rf build",
@@ -36,6 +38,7 @@
   },
   "homepage": "https://github.com/ide/await-lock",
   "jest": {
+    "coverageDirectory": "<rootDir>/..",
     "rootDir": "src"
   },
   "devDependencies": {


### PR DESCRIPTION
The source map references the .ts file under `src` -- include it in the published package while still excluding tests.

Ran npm pack to verify:
```
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 1.1kB README.md
npm notice 1.5kB build/AwaitLock.d.ts
npm notice 4.8kB build/AwaitLock.js
npm notice 1.7kB build/AwaitLock.js.map
npm notice 1.3kB package.json
npm notice 2.7kB src/AwaitLock.ts
```

Closes #23